### PR TITLE
Stop background callbacks from serving a previous job's result

### DIFF
--- a/app_config.py
+++ b/app_config.py
@@ -44,13 +44,38 @@ if multiprocess.get_start_method(allow_none=True) is None:
 
 
 class SafeDiskcacheManager(DiskcacheManager):
-    """DiskcacheManager that silently ignores already-terminated processes on cancel."""
+    """DiskcacheManager that silently ignores already-terminated processes on cancel.
+
+    It also drops whatever sits at a job's result key before that job starts.
+    Dash keys a background callback's result by the hash of its argument values,
+    and a result is meant to be read once: the browser polls for it and the read
+    deletes it. A job whose poll chain stops early never performs that read --
+    the renderer supersedes a running job as soon as one of its inputs changes
+    again, and the superseded job can still finish and write its result before
+    the kill reaches it -- so the entry is left behind under that key.
+
+    Nothing ages those leftovers out, and the next invocation whose arguments
+    hash to the same key is served one instead of running: Dash finds a result
+    already sitting at the key, returns it and terminates the job it just
+    started. Picking x/y/c back and forth on a 2D scatter is exactly that case,
+    since every other argument stays put, so the key repeats as soon as a
+    combination is revisited. When the leftover is a real figure the plot merely
+    shows a recomputation of the same inputs; when it is the `no_update` that a
+    PreventUpdate stored (the frame was not buffered yet when that job ran), the
+    figure silently does not update at all.
+    """
 
     def terminate_job(self, job):
         try:
             super().terminate_job(job)
         except psutil.NoSuchProcess:
             pass
+
+    def call_job_fn(self, key, job_fn, args, context):
+        self.clear_cache_entry(key)
+        self.clear_cache_entry(self._make_progress_key(key))
+        self.clear_cache_entry(self._make_set_props_key(key))
+        return super().call_job_fn(key, job_fn, args, context)
 
 
 APP_TITLE = "SensorView"

--- a/tests/test_2d_frame_trigger_wiring.py
+++ b/tests/test_2d_frame_trigger_wiring.py
@@ -1,0 +1,62 @@
+"""Each 2D scatter regenerates per frame off its own Frame/All switch.
+
+The two panes are near-copies of each other, which is how the right pane came to
+gate its per-frame regeneration on ``scatter2dl-allframe-switch`` -- the left
+pane's switch. The panes are independent: with A on All and B on Frame, moving
+the slider left B untouched, because the trigger it needs was gated on a switch
+belonging to the other pane. These tests read the wiring Dash actually
+registered, so a copy-paste between the two modules cannot reintroduce it.
+
+Author: Zhengyu Peng
+License: GPL-3.0
+"""
+
+import dash
+import pytest
+
+from view_callbacks.scatter_2d_left_view import get_scatter_2d_left_view_callbacks
+from view_callbacks.scatter_2d_right_view import get_scatter_2d_right_view_callbacks
+
+PANES = {
+    "left": (get_scatter_2d_left_view_callbacks, "l"),
+    "right": (get_scatter_2d_right_view_callbacks, "r"),
+}
+
+
+def dependency_ids(app, callback_id, kind):
+    """The component ids a registered callback reads or writes."""
+    return [dep["id"] for dep in app.callback_map[callback_id][kind]]
+
+
+@pytest.fixture(params=sorted(PANES))
+def pane(request):
+    """One pane's registered callbacks, on an app of its own."""
+    register, _ = PANES[request.param]
+    app = dash.Dash(__name__)
+    register(app)
+    return request.param, app
+
+
+class TestFrameTrigger:
+    def test_reads_its_own_scope_switch(self, pane):
+        side, app = pane
+        _, letter = PANES[side]
+
+        inputs = dependency_ids(app, f"..{side}-regenerate-trigger.data..", "inputs")
+
+        # The crux: the pane's own switch, not the other pane's.
+        assert f"scatter2d{letter}-allframe-switch" in inputs
+
+    def test_reads_no_dependency_of_the_other_pane(self, pane):
+        side, app = pane
+        other = "right" if side == "left" else "left"
+        other_letter = PANES[other][1]
+
+        callback_id = f"..{side}-regenerate-trigger.data.."
+        referenced = dependency_ids(app, callback_id, "inputs") + dependency_ids(
+            app, callback_id, "state"
+        )
+
+        assert f"scatter2d{other_letter}-allframe-switch" not in referenced
+        assert f"{other}-switch" not in referenced
+        assert f"{other}-regenerate-trigger" not in referenced

--- a/tests/test_background_result_cache.py
+++ b/tests/test_background_result_cache.py
@@ -1,0 +1,78 @@
+"""Background callback results are never served from a previous job.
+
+Dash keys a background callback's result by the hash of its argument values and
+expects the browser to read -- and thereby delete -- that result once. A job
+whose poll chain stopped early never performs the read, so its result is left
+behind under a key that repeats the moment the same arguments come round again:
+flipping a 2D scatter's x/y/c back and forth holds every other argument still.
+Dash then serves the leftover and kills the job it just started, which shows up
+as a plot that does not update when the leftover is the ``no_update`` a
+PreventUpdate stored.
+
+``SafeDiskcacheManager`` drops the key before the job starts. These tests pin
+that, including the ordering the fix rests on: the drop has to happen before the
+job is handed over, not after.
+
+Author: Zhengyu Peng
+License: GPL-3.0
+"""
+
+import pytest
+
+from dash import DiskcacheManager
+from diskcache import FanoutCache
+
+from app_config import SafeDiskcacheManager
+
+NO_UPDATE = {"_dash_no_update": "_dash_no_update"}
+
+
+@pytest.fixture
+def manager(tmp_path):
+    """A manager over a cache of its own, so tests cannot see each other."""
+    return SafeDiskcacheManager(FanoutCache(str(tmp_path / "dash")))
+
+
+@pytest.fixture
+def started(monkeypatch):
+    """Record what the result store held when the job was handed to Dash."""
+    record = {}
+
+    def fake_call_job_fn(self, key, job_fn, args, context):
+        record["result_at_start"] = self.handle.get(key, "<empty>")
+        record["args"] = args
+        return 4242
+
+    monkeypatch.setattr(DiskcacheManager, "call_job_fn", fake_call_job_fn)
+    return record
+
+
+class TestLeftoverResult:
+    def test_stale_no_update_is_dropped_before_the_job_starts(self, manager, started):
+        # The crux: a PreventUpdate left by an earlier job at this key would be
+        # handed to the browser instead of what this job is about to compute.
+        manager.handle.set("key", NO_UPDATE)
+
+        manager.call_job_fn("key", None, {}, {})
+
+        assert started["result_at_start"] == "<empty>"
+
+    def test_stale_figure_is_dropped_too(self, manager, started):
+        manager.handle.set("key", {"figure": "from a previous job"})
+
+        manager.call_job_fn("key", None, {}, {})
+
+        assert started["result_at_start"] == "<empty>"
+
+    def test_progress_and_set_props_are_dropped(self, manager, started):
+        manager.handle.set(manager._make_progress_key("key"), [50, "half way"])
+        manager.handle.set(manager._make_set_props_key("key"), {"id": {"a": 1}})
+
+        manager.call_job_fn("key", None, {}, {})
+
+        assert manager.get_progress("key") is None
+        assert manager.get_updated_props("key") == {}
+
+    def test_the_job_is_still_started(self, manager, started):
+        assert manager.call_job_fn("key", None, {"x": 1}, {}) == 4242
+        assert started["args"] == {"x": 1}

--- a/view_callbacks/scatter_2d_right_view.py
+++ b/view_callbacks/scatter_2d_right_view.py
@@ -51,7 +51,7 @@ def get_scatter_2d_right_view_callbacks(app):
         inputs={
             "unused_slider_arg": Input("slider-frame", "value"),
             "unused_play_stop_click": Input("play-stop-button", "n_clicks"),
-            "all_frame_sw": Input("scatter2dl-allframe-switch", "value"),
+            "all_frame_sw": Input("scatter2dr-allframe-switch", "value"),
         },
         state={
             "ispaused": State("interval-component", "disabled"),


### PR DESCRIPTION
Changing x, y or c on a 2D scatter sometimes left the plot untouched.

Dash keys a background callback's result by the hash of its argument
values and expects the browser to read that result exactly once -- the
read is what deletes it. A job whose poll chain stops early never
performs the read: the renderer supersedes a running job the moment one
of its inputs changes again, and a superseded job can still finish and
write its result before the kill reaches it. The entry then sits in the
result store with nothing to age it out.

Those keys repeat. Flipping x/y/c back and forth holds every other
argument still, so revisiting a combination rebuilds a key some earlier
job already wrote to, and Dash serves that leftover: it finds a result
waiting, hands it over and terminates the job it just started. A
leftover figure is merely a recomputation of the same inputs, but a
leftover `no_update` -- what PreventUpdate stores when the frame was not
buffered yet -- means the figure never updates, and the fresh job that
would have drawn it is killed.

Drop the result, progress and set_props entries for a key before the job
starts, so the only result the browser can read is the one this
invocation produced.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015mqVK8vRbff6uzMAihAJ2h